### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 
     <groupId>io.github.fileanalysissuite.adaptersdk.convenience</groupId>
     <artifactId>adaptersdk-convenience</artifactId>
+    <name>adaptersdk-convenience</name>
     <version>1.1.0-SNAPSHOT</version>
 
     <description>FAS Custom Adapter Java SDK Convenience Objects</description>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.